### PR TITLE
Reduced psm protein schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,11 @@
     -->
 
     <properties>
-        <archive.repo.version>0.1.19</archive.repo.version>
+        <java.version>1.7</java.version>
+        <archive.repo.version>1.0.0</archive.repo.version>
         <archive.data.provider.api.version>2.0.6</archive.data.provider.api.version>
-        <protein.identification.index.search.version>1.0.1-REDUCED_SCHEMA-SNAPSHOT</protein.identification.index.search.version>
-        <psm.index.search.version>1.0.1-DEV-REDUCED_SCHEMA-SNAPSHOT</psm.index.search.version>
+        <protein.identification.index.search.version>1.0.1</protein.identification.index.search.version>
+        <psm.index.search.version>1.0.1</psm.index.search.version>
         <ontology.index.search.version>1.0.0</ontology.index.search.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.ac.ebi.pride.archive</groupId>
     <artifactId>archive-search</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11-PSM_PROT_REDUCED_SCHEMA_MONGO_SNAPSHOT</version>
 
     <!--
         This project requires several maven profiles to build and run correctly.
@@ -29,8 +29,8 @@
     <properties>
         <archive.repo.version>0.1.19</archive.repo.version>
         <archive.data.provider.api.version>2.0.6</archive.data.provider.api.version>
-        <protein.identification.index.search.version>1.0.0</protein.identification.index.search.version>
-        <psm.index.search.version>1.0.0</psm.index.search.version>
+        <protein.identification.index.search.version>1.0.1-REDUCED_SCHEMA-SNAPSHOT</protein.identification.index.search.version>
+        <psm.index.search.version>1.0.1-DEV-REDUCED_SCHEMA-SNAPSHOT</psm.index.search.version>
         <ontology.index.search.version>1.0.0</ontology.index.search.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.ac.ebi.pride.archive</groupId>
     <artifactId>archive-search</artifactId>
-    <version>1.0.11-PSM_PROT_REDUCED_SCHEMA_MONGO_SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
 
     <!--
         This project requires several maven profiles to build and run correctly.

--- a/src/main/java/uk/ac/ebi/pride/archive/search/service/ProjectIndexService.java
+++ b/src/main/java/uk/ac/ebi/pride/archive/search/service/ProjectIndexService.java
@@ -35,11 +35,9 @@ public class ProjectIndexService {
     }
 
     public void addProject(ProjectProvider project,
-                    Collection<? extends AssayProvider> assays,
-                    Collection<? extends ProteinReferenceProvider> proteinReferences,
-                    Collection<? extends PeptideSequenceProvider> peptideSequences
+                    Collection<? extends AssayProvider> assays
     ) {
-        this.projectIndexDao.addProject(project,assays, proteinReferences, peptideSequences);
+        this.projectIndexDao.addProject(project,assays);
     }
 
     public void addProject(ProjectProvider project) {

--- a/src/main/java/uk/ac/ebi/pride/archive/search/service/dao/ProjectIndexDao.java
+++ b/src/main/java/uk/ac/ebi/pride/archive/search/service/dao/ProjectIndexDao.java
@@ -12,17 +12,14 @@ import java.util.Collection;
  * @version $Id$
  */
 public interface ProjectIndexDao {
-    //    void indexAllProjects();
+
     void indexAllPublicProjects();
 
     void indexAllNonExistingPublicProjects();
 
     void addProject(ProjectProvider project,
-                    Collection<? extends AssayProvider> assays,
-                    Collection<? extends ProteinReferenceProvider> proteinReferences, // a Map from assay accessions to protein references
-                    Collection<? extends PeptideSequenceProvider> peptideSequences
+                    Collection<? extends AssayProvider> assays
     );
-
 
     void addProject(ProjectProvider project);
 }

--- a/src/main/java/uk/ac/ebi/pride/archive/search/service/dao/solr/ProjectIndexDaoSolr.java
+++ b/src/main/java/uk/ac/ebi/pride/archive/search/service/dao/solr/ProjectIndexDaoSolr.java
@@ -6,7 +6,11 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.access.method.P;
 import uk.ac.ebi.pride.archive.dataprovider.assay.AssayProvider;
+import uk.ac.ebi.pride.archive.dataprovider.identification.IdentificationProvider;
 import uk.ac.ebi.pride.archive.dataprovider.identification.PeptideSequenceProvider;
 import uk.ac.ebi.pride.archive.dataprovider.identification.ProteinIdentificationProvider;
 import uk.ac.ebi.pride.archive.dataprovider.identification.ProteinReferenceProvider;
@@ -22,9 +26,11 @@ import uk.ac.ebi.pride.archive.search.util.SolrQueryFactory;
 import uk.ac.ebi.pride.archive.search.util.modelmapper.SolrProjectMapper;
 import uk.ac.ebi.pride.proteinidentificationindex.search.model.ProteinIdentification;
 import uk.ac.ebi.pride.proteinidentificationindex.search.service.ProteinIdentificationSearchService;
+import uk.ac.ebi.pride.psmindex.search.model.Psm;
 import uk.ac.ebi.pride.psmindex.search.service.PsmSearchService;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -35,235 +41,126 @@ import java.util.List;
  */
 public class ProjectIndexDaoSolr implements ProjectIndexDao {
 
-    private static Logger logger = LoggerFactory.getLogger(ProjectIndexDaoSolr.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(ProjectIndexDaoSolr.class.getName());
 
-    private SolrServer projectServer;
-    private ProjectRepository projectRepository;
-    private AssayRepository assayRepository;
-    private OntologyTermSearchService ontologyTermSearchService;
-    private ProteinIdentificationSearchService proteinIdentificationSearchService;
-    private PsmSearchService psmSearchService;
+  private SolrServer projectServer;
+  private ProjectRepository projectRepository;
+  private AssayRepository assayRepository;
+  private OntologyTermSearchService ontologyTermSearchService;
 
+  public ProjectIndexDaoSolr(SolrServer projectServer,
+                             ProjectRepository projectRepository,
+                             AssayRepository assayRepository,
+                             OntologyTermSearchService ontologyTermSearchService) {
+    this.projectServer = projectServer;
+    this.projectRepository = projectRepository;
+    this.assayRepository = assayRepository;
+    this.ontologyTermSearchService = ontologyTermSearchService;
 
-    @Deprecated
-    public ProjectIndexDaoSolr(SolrServer projectServer,
-                               ProjectRepository projectRepository,
-                               AssayRepository assayRepository,
-                               OntologyTermSearchService ontologyTermSearchService,
-                               ProteinIdentificationSearchService proteinIdentificationSearchService) {
-        this.projectServer = projectServer;
-        this.projectRepository = projectRepository;
-        this.assayRepository = assayRepository;
-        this.ontologyTermSearchService = ontologyTermSearchService;
-        this.proteinIdentificationSearchService = proteinIdentificationSearchService;
+  }
 
-    }
-
-    public ProjectIndexDaoSolr(SolrServer projectServer,
-                               ProjectRepository projectRepository,
-                               AssayRepository assayRepository,
-                               OntologyTermSearchService ontologyTermSearchService,
-                               ProteinIdentificationSearchService proteinIdentificationSearchService,
-                               PsmSearchService psmSearchService) {
-        this.projectServer = projectServer;
-        this.projectRepository = projectRepository;
-        this.assayRepository = assayRepository;
-        this.ontologyTermSearchService = ontologyTermSearchService;
-        this.proteinIdentificationSearchService = proteinIdentificationSearchService;
-        this.psmSearchService = psmSearchService;
-
-    }
-
-
-    @Override
-    public void indexAllPublicProjects() {
-
-        // get all projects on repository
-        Iterable<? extends ProjectProvider> projects = projectRepository.findAll();
-
-        deleteIndex();
-
-        try {
-            for (ProjectProvider project : projects) {
-                if (project.getPublicationDate() != null) { // we are going to index just public projects
-                    createAndIndexSolrProject(project);
-                }
-            }
-        } catch (SolrServerException e) {
-            e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
-        } catch (IOException e) {
-            e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
+  @Override
+  public void indexAllPublicProjects() {
+    Iterable<? extends ProjectProvider> projects = projectRepository.findAll();
+    deleteIndex();
+    try {
+      for (ProjectProvider project : projects) {
+        if (project.getPublicationDate() != null) { // we are going to index just public projects
+          createAndIndexSolrProject(project);
         }
-
+      }
+    } catch (SolrServerException|IOException e) {
+      logger.error("Exception indexing Solr", e);
     }
+  }
 
-    @Override
-    public void indexAllNonExistingPublicProjects() {
-
-        // get all projects on repository
-        Iterable<? extends ProjectProvider> projects = projectRepository.findAll();
-
-        try {
-            for (ProjectProvider project : projects) {
-                if (project.getPublicationDate() != null) { // we are going to index just public projects
-                    // just index projects not previously indexed
-                    SolrQuery projectExistsSolrQuery = SolrQueryFactory.getBasicEDismaxQuery("id:" + project.getAccession(), null, null);
-                    QueryResponse res = projectServer.query(projectExistsSolrQuery);
-                    if (res.getBeans(SolrProject.class).size()==0) {
-                        createAndIndexSolrProject(project);
-                    } else {
-                        logger.info("Project " + project.getAccession() + " already in the index. SKIPPING...");
-                    }
-                }
-            }
-        } catch (SolrServerException e) {
-            e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
-        } catch (IOException e) {
-            e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
-        }
-
-
-    }
-
-    @Override
-    public void addProject(ProjectProvider project,
-                           Collection<? extends AssayProvider> assays,
-                           Collection<? extends ProteinReferenceProvider> proteinReferences,
-                           Collection<? extends PeptideSequenceProvider> peptideSequences) {
-
-        //TODO Check if need to be deleted
-        try {
-            SolrProjectMapper solrProject = new SolrProjectMapper(project, assays, proteinReferences, peptideSequences);
-
-            // populate relatives
-            if (ontologyTermSearchService != null)
-                CvParamHelperMethods.populateRelatives(solrProject, ontologyTermSearchService);
-
-            projectServer.addBean(solrProject);
-            projectServer.commit();
-        } catch (SolrServerException e) {
-            e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
-        } catch (IOException e) {
-            e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
-        }
-
-    }
-
-    @Override
-    public void addProject(ProjectProvider project) {
-        try {
+  @Override
+  public void indexAllNonExistingPublicProjects() {
+    Iterable<? extends ProjectProvider> projects = projectRepository.findAll();
+    try {
+      for (ProjectProvider project : projects) {
+        if (project.getPublicationDate() != null) { // we are going to index just public projects not previously indexed
+          SolrQuery projectExistsSolrQuery = SolrQueryFactory.getBasicEDismaxQuery("id:" + project.getAccession(), null, null);
+          QueryResponse res = projectServer.query(projectExistsSolrQuery);
+          if (res.getBeans(SolrProject.class).size()==0) {
             createAndIndexSolrProject(project);
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (SolrServerException e) {
-            e.printStackTrace();
+          } else {
+            logger.info("Project " + project.getAccession() + " already in the index. SKIPPING...");
+          }
         }
+      }
+    } catch (SolrServerException|IOException e) {
+      logger.error("Exception indexing Solr", e);
     }
+  }
 
-    private void deleteIndex() {
-        try {
-            //WARNING: deletes ALL entries from index
-            projectServer.deleteByQuery("*:*");
-            projectServer.commit();
-            logger.info("All index entries deleted!");
-        } catch (SolrServerException e) {
-            throw new RuntimeException("Failed to delete data in Solr. "
-                    + e.getMessage(), e);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to delete data in Solr. "
-                    + e.getMessage(), e);
-        }
+  @Override
+  public void addProject(ProjectProvider project) {
+    try {
+      createAndIndexSolrProject(project);
+    } catch (SolrServerException|IOException e) {
+      logger.error("Exception indexing Solr", e);
     }
+  }
 
-    public void deleteProjectFromIndexAndReindex(String projectAccession) {
-        try {
-            deleteProjectFromIndex(projectAccession);
-            ProjectProvider project = projectRepository.findByAccession(projectAccession);
-             if (project.getPublicationDate() != null) { // we are going to index just public projects
-                 createAndIndexSolrProject(project);
-             } else {
-                 logger.error("Not indexing project, it does not have a publication date.");
-             }
-        } catch (SolrServerException|IOException e) {
-            throw new RuntimeException("Failed to delete data in Solr. ", e);
-        }
-    }
-
-    public void deleteProjectFromIndex(String projectAccession) throws IOException, SolrServerException {
-        projectServer.deleteByQuery("id:" + projectAccession);
-        projectServer.commit();
-        logger.info("Project " + projectAccession + " deleted from index!");
-    }
-
-
-    private void createAndIndexSolrProject(ProjectProvider project) throws IOException, SolrServerException {
-
-        List<? extends ProteinIdentificationProvider> proteinIdentifications = getProteinIdentificationsForProject(project);
-        Collection<PeptideSequenceProvider> peptideSequences = getPeptideSequencesForProject(project);
-
-        logger.info("Got " + proteinIdentifications.size() + " protein identifications from Protein index for project " + project.getAccession());
-        logger.info("Got " + peptideSequences.size() + " peptide sequences from PSM index for project " + project.getAccession());
-
-        //create the solr object with proteins and peptide sequences
-        SolrProjectMapper solrProject = new SolrProjectMapper(
-                project,
-                assayRepository.findAllByProjectId(project.getId()),
-                proteinIdentifications,
-                peptideSequences
-        );
-
-        // populate relatives
+  @Override
+  public void addProject(ProjectProvider project,
+                         Collection<? extends AssayProvider> assays) {
+    try {
+      SolrProjectMapper solrProject = new SolrProjectMapper(project, assays);
+      if (ontologyTermSearchService != null) {
         CvParamHelperMethods.populateRelatives(solrProject, ontologyTermSearchService);
-
-        //Reminder: solrProject.getPeptideSequences() and solrProject.getProteinIdentifications() will return null
-        //because the field is indexed but not stored
-
-        logger.info("Project accession: " + solrProject.getAccession());
-
-        projectServer.addBean(solrProject);
-        projectServer.commit();
-        logger.info("Indexed project " + solrProject.getAccession());
+      }
+      projectServer.addBean(solrProject);
+      projectServer.commit();
+    } catch (SolrServerException | IOException e) {
+      logger.error("Exception indexing Solr", e);
     }
+  }
 
-    private List<? extends ProteinIdentificationProvider> getProteinIdentificationsForProject(ProjectProvider project) {
-        List<ProteinIdentification> proteinIdentifications = new LinkedList<ProteinIdentification>();
-        // build protein identifications from protein identification service
-        if (proteinIdentificationSearchService != null) {
-            proteinIdentifications = proteinIdentificationSearchService.findByProjectAccession(project.getAccession());
-        } else {
-            logger.warn("Protein identification index not available. Protein identifications and synonyms will not be added.");
-        }
-        return proteinIdentifications;
+  private void deleteIndex() {
+    try {  //WARNING: deletes ALL entries from index
+      projectServer.deleteByQuery("*:*");
+      projectServer.commit();
+      logger.info("All index entries deleted!");
+    } catch (SolrServerException|IOException e) {
+      logger.error("Exception indexing Solr", e);
     }
+  }
 
-    /**
-     *  Retrieves peptide sequences from the psm store
-     * @param project Project to query the psm store and retrieve the peptides
-     * @return peptide sequences
-     */
-    private Collection<PeptideSequenceProvider> getPeptideSequencesForProject(ProjectProvider project) {
-        Collection<PeptideSequenceProvider> peptideSequences = new LinkedList<PeptideSequenceProvider>();
-        // build protein identifications from psm service
-        if (psmSearchService != null) {
-            peptideSequences = buildPeptideSequenceProviderItems(psmSearchService.findPeptideSequencesByProjectAccession(project.getAccession()));
-        } else {
-            logger.warn("Psm index not available. Peptide sequences will not be added.");
-        }
-        return peptideSequences;
+  public void deleteProjectFromIndexAndReindex(String projectAccession) {
+    try {
+      deleteProjectFromIndex(projectAccession);
+      ProjectProvider project = projectRepository.findByAccession(projectAccession);
+      if (project.getPublicationDate() != null) { // we are going to index just public projects
+        createAndIndexSolrProject(project);
+      } else {
+        logger.error("Not indexing project, it does not have a publication date.");
+      }
+    } catch (SolrServerException|IOException e) {
+      logger.error("Exception indexing Solr", e);
     }
+  }
 
-    private Collection<PeptideSequenceProvider> buildPeptideSequenceProviderItems(List<String> peptideSequences) {
+  public void deleteProjectFromIndex(String projectAccession) throws IOException, SolrServerException {
+    projectServer.deleteByQuery("id:" + projectAccession);
+    projectServer.commit();
+    logger.info("Project " + projectAccession + " deleted from index!");
+  }
 
-        Collection<PeptideSequenceProvider> res = new LinkedList<PeptideSequenceProvider>();
 
-        if(peptideSequences!=null) {
-            for (String sequence: peptideSequences) {
-                SolrPeptideSequence peptideSequence = new SolrPeptideSequence();
-                peptideSequence.setPeptideSequence(sequence);
-                res.add(peptideSequence);
-            }
-        }
-        return res;
-    }
+  private void createAndIndexSolrProject(ProjectProvider project) throws IOException, SolrServerException {
+    //create the solr object with proteins and peptide sequences
+    SolrProjectMapper solrProject = new SolrProjectMapper(project, assayRepository.findAllByProjectId(project.getId()));
 
+    // populate relatives
+    CvParamHelperMethods.populateRelatives(solrProject, ontologyTermSearchService);
+
+    //Reminder: solrProject.getPeptideSequences() and solrProject.getProteinIdentifications() will return null
+    //because the field is indexed but not stored
+    logger.info("Project accession: " + solrProject.getAccession());
+    projectServer.addBean(solrProject);
+    projectServer.commit();
+    logger.info("Indexed project " + solrProject.getAccession());
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/archive/search/tools/ProjectIndexBuilder.java
+++ b/src/main/java/uk/ac/ebi/pride/archive/search/tools/ProjectIndexBuilder.java
@@ -29,10 +29,6 @@ public class ProjectIndexBuilder {
     //Solr Repositories
     @Autowired
     private OntologyTermSearchService ontologyTermSearchService;
-    @Autowired
-    private PsmSearchService psmSearchService;
-    @Autowired
-    private ProteinIdentificationSearchService proteinIdentificationSearchService;
 
     /*
     HttpSolrServer is thread-safe and if you are using the following constructor,
@@ -68,9 +64,7 @@ public class ProjectIndexBuilder {
                 projectIndexBuilder.solrProjectServer,
                 projectIndexBuilder.projectRepository,
                 projectIndexBuilder.assayRepository,
-                projectIndexBuilder.ontologyTermSearchService,
-                projectIndexBuilder.proteinIdentificationSearchService,
-                projectIndexBuilder.psmSearchService
+                projectIndexBuilder.ontologyTermSearchService
                 ));
 
         projectIndexService.indexAllPublicProjects();
@@ -83,9 +77,7 @@ public class ProjectIndexBuilder {
                 projectIndexBuilder.solrProjectServer,
                 projectIndexBuilder.projectRepository,
                 projectIndexBuilder.assayRepository,
-                projectIndexBuilder.ontologyTermSearchService,
-                projectIndexBuilder.proteinIdentificationSearchService,
-                projectIndexBuilder.psmSearchService
+                projectIndexBuilder.ontologyTermSearchService
         ));
 
         projectIndexService.indexAllNonExistingPublicProjects();

--- a/src/main/java/uk/ac/ebi/pride/archive/search/util/modelmapper/SolrProjectMapper.java
+++ b/src/main/java/uk/ac/ebi/pride/archive/search/util/modelmapper/SolrProjectMapper.java
@@ -25,17 +25,13 @@ public class SolrProjectMapper extends SolrProject {
 
     public static final String NODOI = "noDOI";
 
-    public SolrProjectMapper(ProjectProvider project, Collection<? extends AssayProvider> assays,
-                             Collection<? extends ProteinReferenceProvider> proteinReferences,
-                             Collection<? extends PeptideSequenceProvider> peptideSequences) {
-        initMethod(project, assays, proteinReferences, peptideSequences);
+    public SolrProjectMapper(ProjectProvider project, Collection<? extends AssayProvider> assays) {
+        initMethod(project, assays);
     }
 
 
     //initialize attributes from Project object
-    private void initMethod(ProjectProvider project, Collection<? extends AssayProvider> assays,
-                            Collection<? extends ProteinReferenceProvider> proteinReferences,
-                            Collection<? extends PeptideSequenceProvider> peptideSequences){
+    private void initMethod(ProjectProvider project, Collection<? extends AssayProvider> assays){
         this.setAccession(project.getAccession());
         this.setDoi(project.getDoi());
         this.setTitle(project.getTitle());
@@ -111,17 +107,6 @@ public class SolrProjectMapper extends SolrProject {
 
         // publication date
         if (project.getPublicationDate() != null) this.setPublicationDate(project.getPublicationDate());
-
-        // protein identifications
-        if (proteinReferences != null) {
-            this.setProteinIdentifications(proteinReferences);
-        }
-
-        // peptide sequences
-        if (peptideSequences != null) {
-            this.setPeptideSequences(peptideSequences);
-        }
-
     }
 
     private int calculateTotalSpectrumCount(ProjectProvider project) {

--- a/src/test/java/uk/ac/ebi/pride/archive/search/integration/MzTabDataProviderReader.java
+++ b/src/test/java/uk/ac/ebi/pride/archive/search/integration/MzTabDataProviderReader.java
@@ -52,13 +52,6 @@ public class MzTabDataProviderReader {
                 if (mzTabFile != null) {
                     // get assay accession
                     String assayAccession = tabFile.getName().split("[_\\.]")[4];
-                    // get proteins
-                    List<ProteinIdentification> proteinIdentifications = ProteinIdentificationMzTabBuilder.readProteinIdentificationsFromMzTabFile(projectAccession, assayAccession, mzTabFile);
-                    enrichProteinIdentificationListWithOtherMappings(proteinIdentifications);
-
-                    // add assay proteins to the result
-                    res.addAll(proteinIdentifications);
-                    logger.info("Found " + proteinIdentifications.size() + " protein identifications for Assay " + assayAccession + " in file " + tabFile.getAbsolutePath());
                 } else {
                     mzTabFileParser.getErrorList().print(errorLogOutputStream);
                 }
@@ -105,44 +98,6 @@ public class MzTabDataProviderReader {
         }
 
         return res;
-    }
-
-
-    /**
-     * For testing purposes only.
-     * In the general case, we don't read the identifications from mzTab, we read them
-     * from the protein identification index that contains the other mappings.
-     * @param proteinReferences list of protein references to be enriched
-     */
-    private static void enrichProteinIdentificationListWithOtherMappings(List<ProteinIdentification> proteinReferences) {
-
-        logger.debug("Processing " + proteinReferences.size() + " proteins");
-
-        Set<String> accessions = new TreeSet<String>();
-        Map<String, String> uniprotMappings;
-        Map<String, String> ensemblMappings;
-        Map<String, TreeSet<String>> otherMappings;
-
-        for (ProteinIdentification protein : proteinReferences) {
-            accessions.add(protein.getAccession());
-        }
-
-        try {
-            uniprotMappings = ProteinAccessionMappingsFinder.findProteinUniprotMappingsForAccession(accessions);
-            ensemblMappings = ProteinAccessionMappingsFinder.findProteinEnsemblMappingsForAccession(accessions);
-            otherMappings = ProteinAccessionMappingsFinder.findProteinOtherMappingsForAccession(accessions);
-
-            for (ProteinIdentification proteinReference : proteinReferences) {
-                String proteinAccession = proteinReference.getAccession();
-                proteinReference.setUniprotMapping(uniprotMappings.get(proteinAccession));
-                proteinReference.setEnsemblMapping(ensemblMappings.get(proteinAccession));
-                proteinReference.setOtherMappings(otherMappings.get(proteinAccession));
-            }
-
-        } catch (IOException e) {
-            logger.error("Cannot get mappings");
-        }
-
     }
 
     /**

--- a/src/test/java/uk/ac/ebi/pride/archive/search/integration/SolrProjectSearchTest.java
+++ b/src/test/java/uk/ac/ebi/pride/archive/search/integration/SolrProjectSearchTest.java
@@ -35,17 +35,6 @@ import java.util.*;
  */
 public class SolrProjectSearchTest extends SolrTestCaseJ4 {
 
-    private static final String PROTEIN_A5A5Z5_ACCESSION = "A5A5Z5";
-
-    private static final String UNIPROT_ACCESSION = "A5A5Z5";
-    private static final String ENSEMBL_ACCESSION = "A5A5Z5";
-    private static final String OTHER_ACCESSION = "UPI0001509A10";
-
-    private static final String FIRST_PEPTIDE_SEQUENCE_PXD000581 = "FLTDRYPISGIFSGK";
-    private static final String SECOND_PEPTIDE_SEQUENCE_PXD000581 = "LLSQTTSVHFHGQVQR";
-    private static final String THIRD_PEPTIDE_SEQUENCE_PXD000581 = "LYGILNHANAPVTR";
-    private static final String FOUR_PEPTIDE_SEQUENCE_PXD000581 = "VHAASTAGPFPDNAVVAR";
-
     private static final String PROJECT_PXD000433_ACCESSION = "PXD000433";
     private static final String PROJECT_PXD000581_ACCESSION = "PXD000581";
     private static final String PROJECT_PXTEST1_ACCESSION = "PXTEST1";
@@ -57,8 +46,8 @@ public class SolrProjectSearchTest extends SolrTestCaseJ4 {
     private SolrServer server;
     private SolrProject solrProject;
 
-    public static final long ZERO_DOCS = 0L;
-    public static final long SINGLE_DOC = 1L;
+    private static final long ZERO_DOCS = 0L;
+    private static final long SINGLE_DOC = 1L;
 
     private static LinkedList<ProteinReferenceProvider> proteinReferencesPXD000433;
     private static LinkedList<PeptideSequenceProvider> peptideSequencesPXD000433;
@@ -151,124 +140,6 @@ public class SolrProjectSearchTest extends SolrTestCaseJ4 {
 
     }
 
-    @Test
-    public void testSearchByProteinAccession() throws SolrServerException, IOException, URISyntaxException, ParseException, MZTabException {
-        String searchAccession = PROTEIN_A5A5Z5_ACCESSION;
-        searchByProteinAccession(searchAccession);
-
-    }
-
-    private void searchByProteinAccession(String searchAccession) throws SolrServerException, IOException, URISyntaxException, ParseException, MZTabException {
-        addProjectPXD000433ToIndex();
-
-        ProjectSearchDao projectSearchDao = new ProjectSearchDaoSolr(server);
-        Collection<? extends ProjectProvider> res =
-                projectSearchDao.searchProjectAny(
-                        SearchFields.PROTEIN_IDENTIFICATIONS.getIndexName() + ":" + searchAccession,
-                        SearchFields.PROTEIN_IDENTIFICATIONS.getIndexName(),
-                        null,
-                        0,
-                        1,
-                        SearchFields.ACCESSION.getIndexName(),
-                        "desc"
-                );
-        // check we found one project
-        assertEquals(1, res.size());
-        // check that is PXD000433
-        checkIsProjectPXD000433(res.iterator().next());
-    }
-
-    // disabled, since it depends on data from an external resource (UniProt) that is not guaranteed to be available
-//    @Test
-//     public void testSearchByOtherProteinAccession() throws SolrServerException, IOException, URISyntaxException, ParseException, MZTabException {
-//        String searchAccession = OTHER_ACCESSION;
-//        searchByProteinAccession(searchAccession);
-//
-//    }
-
-    @Test
-    public void testSearchByUniprotProteinAccession() throws SolrServerException, IOException, URISyntaxException, ParseException, MZTabException {
-        String searchAccession = UNIPROT_ACCESSION;
-        searchByProteinAccession(searchAccession);
-
-    }
-
-
-    @Test
-    public void testSearchByPeptide() throws SolrServerException, IOException, URISyntaxException, ParseException, MZTabException {
-        addProjectPXD000581ToIndex();
-
-        ProjectSearchDao projectSearchDao = new ProjectSearchDaoSolr(server);
-
-        Collection<? extends ProjectProvider> all =
-                projectSearchDao.searchProjectAny(
-                        SearchFields.PEPTIDE_SEQUENCES.getIndexName() + ":" + "*",
-                        SearchFields.PEPTIDE_SEQUENCES.getIndexName(),
-                        null,
-                        0,
-                        1,
-                        SearchFields.ACCESSION.getIndexName(),
-                        "desc"
-                );
-
-        Collection<? extends ProjectProvider> res =
-                projectSearchDao.searchProjectAny(
-                        SearchFields.PEPTIDE_SEQUENCES.getIndexName() + ":" + FIRST_PEPTIDE_SEQUENCE_PXD000581,
-                        SearchFields.PEPTIDE_SEQUENCES.getIndexName(),
-                        null,
-                        0,
-                        1,
-                        SearchFields.ACCESSION.getIndexName(),
-                        "desc"
-                );
-        // check we found one project
-        assertEquals(1, res.size());
-        // check that is PXD000581
-        checkIsProjectPXD000581(res.iterator().next());
-
-        res = projectSearchDao.searchProjectAny(
-                SearchFields.PEPTIDE_SEQUENCES.getIndexName() + ":" + SECOND_PEPTIDE_SEQUENCE_PXD000581,
-                SearchFields.PEPTIDE_SEQUENCES.getIndexName(),
-                null,
-                0,
-                1,
-                SearchFields.ACCESSION.getIndexName(),
-                "desc"
-        );
-        // check we found one project
-        assertEquals(1, res.size());
-        // check that is PXD000433
-        checkIsProjectPXD000581(res.iterator().next());
-
-        res = projectSearchDao.searchProjectAny(
-                SearchFields.PEPTIDE_SEQUENCES.getIndexName() + ":" + THIRD_PEPTIDE_SEQUENCE_PXD000581,
-                SearchFields.PEPTIDE_SEQUENCES.getIndexName(),
-                null,
-                0,
-                1,
-                SearchFields.ACCESSION.getIndexName(),
-                "desc"
-        );
-        // check we found one project
-        assertEquals(1, res.size());
-        // check that is PXD000433
-        checkIsProjectPXD000581(res.iterator().next());
-
-        res = projectSearchDao.searchProjectAny(
-                SearchFields.PEPTIDE_SEQUENCES.getIndexName() + ":" + FOUR_PEPTIDE_SEQUENCE_PXD000581,
-                SearchFields.PEPTIDE_SEQUENCES.getIndexName(),
-                null,
-                0,
-                1,
-                SearchFields.ACCESSION.getIndexName(),
-                "desc"
-        );
-        // check we found one project
-        assertEquals(1, res.size());
-        // check that is PXD000433
-        checkIsProjectPXD000581(res.iterator().next());
-    }
-
     private void checkIsProjectPXD000433(ProjectProvider searchResult) {
 
         SolrProject resSolrProject = (SolrProject) searchResult;
@@ -305,8 +176,8 @@ public class SolrProjectSearchTest extends SolrTestCaseJ4 {
         solrProject.setProjectTagNames(Arrays.asList("Biological","Technical"));
 
         //add a new project to index
-        ProjectIndexDao projectIndexDao = new ProjectIndexDaoSolr(server, null, null, null, null, null);
-        projectIndexDao.addProject(solrProject, null, null, null );
+        ProjectIndexDao projectIndexDao = new ProjectIndexDaoSolr(server, null, null, null);
+        projectIndexDao.addProject(solrProject, null);
 
     }
 
@@ -340,8 +211,8 @@ public class SolrProjectSearchTest extends SolrTestCaseJ4 {
 
 
         //add a new project to index
-        ProjectIndexDao projectIndexDao = new ProjectIndexDaoSolr(server, null, null, null, null, null);
-        projectIndexDao.addProject(solrProject, null, proteinReferencesPXD000433, peptideSequencesPXD000433);
+        ProjectIndexDao projectIndexDao = new ProjectIndexDaoSolr(server, null, null, null);
+        projectIndexDao.addProject(solrProject, null);
 
     }
 
@@ -378,8 +249,8 @@ public class SolrProjectSearchTest extends SolrTestCaseJ4 {
         }
 
         //add a new project to index
-        ProjectIndexDao projectIndexDao = new ProjectIndexDaoSolr(server, null, null, null, null, null);
-        projectIndexDao.addProject(solrProject, null, proteinReferencesPXD000581, peptideSequencesPXD000581);
+        ProjectIndexDao projectIndexDao = new ProjectIndexDaoSolr(server, null, null, null);
+        projectIndexDao.addProject(solrProject, null);
 
     }
 }


### PR DESCRIPTION
PSM and Protein ID Solr schemas have been updated and reduced to hold less information. This library has been updated to use these latest dependencies, as well as removing the functionality of indexing PSMs and Protein IDs here - this is done by separate libraries.